### PR TITLE
GUVNOR-3014: Indexing errors after importing the stock examples

### DIFF
--- a/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/src/main/java/org/jbpm/formModeler/panels/modeler/backend/indexing/FormIndexVisitor.java
+++ b/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/src/main/java/org/jbpm/formModeler/panels/modeler/backend/indexing/FormIndexVisitor.java
@@ -33,7 +33,8 @@ public class FormIndexVisitor extends ResourceReferenceCollector {
     private final Form form;
 
     public FormIndexVisitor(Form form) {
-        this.form = PortablePreconditions.checkNotNull("form", form);
+        this.form = PortablePreconditions.checkNotNull("form",
+                                                       form);
     }
 
     public void visit() {
@@ -41,77 +42,87 @@ public class FormIndexVisitor extends ResourceReferenceCollector {
     }
 
     protected void visit(Form form) {
-        Resource res = addResource(form.getName(), ResourceType.FORM);
+        Resource res = addResource(form.getName(),
+                                   ResourceType.FORM);
 
         for (Field field : form.getFormFields()) {
-            visit(field, res);
+            visit(field,
+                  res);
         }
 
         for (DataHolder dataHolder : form.getHolders()) {
-            visit(dataHolder, res);
+            visit(dataHolder);
         }
     }
 
-    protected void visit(DataHolder dataHolder, Resource res) {
+    protected void visit(DataHolder dataHolder) {
         String className = dataHolder.getClassName();
         ResourceReference resRef = null;
         // it's apparently possible for the class name to be null!
         // See org.jbpm.formModeler.core.model.BasicTypeDataHolder.getClassName()
-        res.addPart(dataHolder.getUniqeId(), PartType.DATAHOLDER);
-        if( className != null ) {
-            resRef = addResourceReference(dataHolder.getClassName(), ResourceType.JAVA);
+        if (className != null) {
+            resRef = addResourceReference(dataHolder.getClassName(),
+                                          ResourceType.JAVA);
 
             if (dataHolder.canHaveChildren()) {
                 for (DataFieldHolder field : dataHolder.getFieldHolders()) {
-                    if (form.isFieldBinded(dataHolder, field.getId()) ) {
-                        System.out.println( "BOUND FIELD: " + dataHolder.getUniqeId() + ":" + field.getId() + " [" + field.getClassName() + "]" );
-                        resRef.addPartReference(field.getId(), PartType.FIELD);
-                        addResourceReference(field.getClassName(), ResourceType.JAVA);
+                    if (form.isFieldBinded(dataHolder,
+                                           field.getId())) {
+                        resRef.addPartReference(field.getId(),
+                                                PartType.FIELD);
+                        addResourceReference(field.getClassName(),
+                                             ResourceType.JAVA);
                     }
                 }
             }
         }
     }
 
-    protected void visit(Field field, Resource res) {
+    protected void visit(Field field,
+                         Resource res) {
         DataHolder holder = field.getForm().getDataHolderByField(field);
 
-        res.addPart(field.getFieldName(), PartType.FORM_FIELD);
+        res.addPart(field.getFieldName(),
+                    PartType.FORM_FIELD);
         if (holder != null) {
             if (holder.canHaveChildren()) {
-                String bindingExpression = StringUtils.defaultIfEmpty(field.getInputBinding(), field.getOutputBinding());
+                String bindingExpression = StringUtils.defaultIfEmpty(field.getInputBinding(),
+                                                                      field.getOutputBinding());
 
                 int slash = bindingExpression.indexOf("/");
                 String holderFieldId = bindingExpression.substring(slash + 1);
                 DataFieldHolder holderField = holder.getDataFieldHolderById(holderFieldId);
                 if (holderField != null) {
-                    addResourceReference(holderField.getClassName(), ResourceType.JAVA);
+                    addResourceReference(holderField.getClassName(),
+                                         ResourceType.JAVA);
                 } else {
                     // any references to parts or other resources here?
                 }
             }
         } else {
             FieldType type = field.getFieldType();
-            if( type != null ) {
-               String fieldClass = type.getFieldClass();
-               if( fieldClass != null && ! fieldClass.isEmpty() ) {
-                   addResourceReference(fieldClass, ResourceType.JAVA);
-               }
+            if (type != null) {
+                String fieldClass = type.getFieldClass();
+                if (fieldClass != null && !fieldClass.isEmpty()) {
+                    addResourceReference(fieldClass,
+                                         ResourceType.JAVA);
+                }
             } else {
                 // empty type.. do we do anything here?
             }
         }
 
         if (!StringUtils.isEmpty(field.getDefaultSubform())) {
-            addResourceReference(field.getDefaultSubform(), ResourceType.FORM);
+            addResourceReference(field.getDefaultSubform(),
+                                 ResourceType.FORM);
         }
         if (!StringUtils.isEmpty(field.getPreviewSubform())) {
-            addResourceReference(field.getDefaultSubform(), ResourceType.FORM);
+            addResourceReference(field.getDefaultSubform(),
+                                 ResourceType.FORM);
         }
         if (!StringUtils.isEmpty(field.getTableSubform())) {
-            addResourceReference(field.getDefaultSubform(), ResourceType.FORM);
+            addResourceReference(field.getDefaultSubform(),
+                                 ResourceType.FORM);
         }
     }
-
-
 }

--- a/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/src/test/java/org/jbpm/formModeler/panels/modeler/backend/indexing/FormIndexVisitorTest.java
+++ b/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/src/test/java/org/jbpm/formModeler/panels/modeler/backend/indexing/FormIndexVisitorTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.formModeler.panels.modeler.backend.indexing;
+
+import java.io.InputStream;
+
+import org.jbpm.formModeler.api.model.DataHolder;
+import org.jbpm.formModeler.api.model.Field;
+import org.jbpm.formModeler.api.model.Form;
+import org.jbpm.formModeler.core.config.DataHolderManager;
+import org.jbpm.formModeler.core.config.FieldTypeManager;
+import org.jbpm.formModeler.core.config.FormManagerImpl;
+import org.jbpm.formModeler.core.config.FormSerializationManager;
+import org.jbpm.formModeler.core.config.FormSerializationManagerImpl;
+import org.jbpm.formModeler.core.config.builders.dataHolder.BasicTypeHolderBuilder;
+import org.jbpm.formModeler.core.config.builders.dataHolder.DataHolderBuildConfig;
+import org.jbpm.formModeler.core.config.builders.dataHolder.PojoDataHolderBuilder;
+import org.jbpm.formModeler.core.model.BasicTypeDataHolder;
+import org.jbpm.formModeler.core.model.PojoDataHolder;
+import org.jbpm.formModeler.dataModeler.integration.DataModelerService;
+import org.jbpm.formModeler.dataModeler.model.DataModelerDataHolder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.refactoring.model.index.Resource;
+import org.kie.workbench.common.services.refactoring.service.PartType;
+import org.kie.workbench.common.services.refactoring.service.ResourceType;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FormIndexVisitorTest {
+
+    public static final String SIMPLE_DATA_HOLDER_FORM = "ReviewAdministration-taskform.form";
+
+    public static final String COMPLEX_DATA_HOLDER_FORM = "PurchaseHeader.form";
+
+    @Mock
+    private DataHolderManager dataHolderManager;
+
+    @Mock
+    private FieldTypeManager fieldTypeManager;
+
+    @Mock
+    private Resource resource;
+
+    private FormSerializationManager serializationManager;
+
+    @Before
+    public void init() {
+        when(dataHolderManager.createDataHolderByType(any(),
+                                                      any())).thenAnswer(new Answer<DataHolder>() {
+            @Override
+            public DataHolder answer(InvocationOnMock invocationOnMock) throws Throwable {
+
+                String holderType = (String) invocationOnMock.getArguments()[0];
+
+                final DataHolder dataHolder = getDataHolder(holderType);
+
+                DataHolderBuildConfig config = (DataHolderBuildConfig) invocationOnMock.getArguments()[1];
+
+                if (dataHolder != null) {
+                    when(dataHolder.getUniqeId()).thenReturn(config.getHolderId());
+                    when(dataHolder.getInputId()).thenReturn(config.getInputId());
+                    when(dataHolder.getOuputId()).thenReturn(config.getOutputId());
+                    when(dataHolder.getRenderColor()).thenReturn(config.getRenderColor());
+                    when(dataHolder.getClassName()).thenReturn(config.getValue());
+                    when(dataHolder.containsBinding(anyString())).thenAnswer(new Answer<Boolean>() {
+                        @Override
+                        public Boolean answer(InvocationOnMock invocationOnMock) throws Throwable {
+                            String binding = (String) invocationOnMock.getArguments()[0];
+                            if (binding == null) {
+                                return Boolean.FALSE;
+                            }
+                            return binding.startsWith(dataHolder.getInputId() + "/") || binding.startsWith(dataHolder.getOuputId() + "/");
+                        }
+                    });
+                    when(dataHolder.canHaveChildren()).thenReturn(!(dataHolder instanceof BasicTypeDataHolder));
+                }
+                return dataHolder;
+            }
+        });
+
+        serializationManager = new FormSerializationManagerImpl() {
+            {
+                formManager = new FormManagerImpl();
+                dataHolderManager = FormIndexVisitorTest.this.dataHolderManager;
+                fieldTypeManager = FormIndexVisitorTest.this.fieldTypeManager;
+            }
+        };
+    }
+
+    private DataHolder getDataHolder(String holderType) {
+        if (holderType.equals(DataModelerService.HOLDER_TYPE_DATA_MODEL)) {
+            return mock(DataModelerDataHolder.class);
+        } else if (holderType.equals(PojoDataHolderBuilder.HOLDER_TYPE_POJO_CLASSNAME)) {
+            return mock(PojoDataHolder.class);
+        } else if (holderType.equals(BasicTypeHolderBuilder.HOLDER_TYPE_BASIC_TYPE)) {
+            return mock(BasicTypeDataHolder.class);
+        }
+        return null;
+    }
+
+    @Test
+    public void testFormWithSimpleDataHolder() throws Exception {
+        runTest(SIMPLE_DATA_HOLDER_FORM);
+    }
+
+    @Test
+    public void testFormWithComplexDataHolder() throws Exception {
+        runTest(COMPLEX_DATA_HOLDER_FORM);
+    }
+
+    protected void runTest(final String formName) throws Exception {
+        InputStream formInputStream = this.getClass().getResourceAsStream(formName);
+
+        Form form = serializationManager.loadFormFromXML(formInputStream);
+
+        FormIndexVisitor visitor = spy(new FormIndexVisitor(form));
+
+        when(visitor.addResource(any(),
+                                 any())).thenReturn(resource);
+
+        visitor.visit();
+
+        verify(visitor,
+               times(form.getFormFields().size())).visit(any(Field.class),
+                                                         any());
+
+        form.getFormFields().forEach(field ->
+                                             verify(resource).addPart(field.getFieldName(),
+                                                                      PartType.FORM_FIELD));
+
+        verify(visitor,
+               times(form.getHolders().size())).visit(any(DataHolder.class));
+
+        form.getHolders().forEach(dataHolder -> {
+                                      verify(resource,
+                                             never()).addPart(dataHolder.getUniqeId(),
+                                                              PartType.DATAHOLDER);
+                                      verify(visitor,
+                                             atLeastOnce()).addResourceReference(dataHolder.getClassName(),
+                                                                                 ResourceType.JAVA);
+                                  }
+        );
+    }
+}


### PR DESCRIPTION
The problem was occuring when the indexed form was including fields with the same name as the Data Holder. Just avoided to index the holder name since the only relevant info there is the type.

@manstis can you take a look?