### PR TITLE
AF-593: Migrate Data Modeller to AppFormer

### DIFF
--- a/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/pom.xml
+++ b/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>uberfire-commons</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-model</artifactId>
     </dependency>

--- a/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/src/main/java/org/jbpm/formModeler/panels/modeler/backend/indexing/FormIndexVisitor.java
+++ b/jbpm-form-modeler-panels/jbpm-form-modeler-editor/jbpm-form-modeler-editor-backend/src/main/java/org/jbpm/formModeler/panels/modeler/backend/indexing/FormIndexVisitor.java
@@ -21,12 +21,12 @@ import org.jbpm.formModeler.api.model.DataHolder;
 import org.jbpm.formModeler.api.model.Field;
 import org.jbpm.formModeler.api.model.FieldType;
 import org.jbpm.formModeler.api.model.Form;
+import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.services.refactoring.Resource;
 import org.kie.workbench.common.services.refactoring.ResourceReference;
 import org.kie.workbench.common.services.refactoring.backend.server.impact.ResourceReferenceCollector;
 import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
-import org.uberfire.commons.validation.PortablePreconditions;
 
 public class FormIndexVisitor extends ResourceReferenceCollector {
 

--- a/jbpm-form-modeler-showcase/pom.xml
+++ b/jbpm-form-modeler-showcase/pom.xml
@@ -103,6 +103,10 @@
       <artifactId>uberfire-commons</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
     </dependency>
@@ -861,6 +865,8 @@
             <compileSourcesArtifact>org.uberfire:uberfire-preferences-ui-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-client</compileSourcesArtifact>
+
+            <compileSourcesArtifact>org.kie.soup:kie-soup-commons</compileSourcesArtifact>
 
             <!-- UberFire -->
             <compileSourcesArtifact>org.uberfire:uberfire-maven-support</compileSourcesArtifact>


### PR DESCRIPTION
Related:
https://github.com/kiegroup/guvnor/pull/519
https://github.com/dashbuilder/dashbuilder/pull/372
https://github.com/kiegroup/kie-soup/pull/3
https://github.com/kiegroup/kie-wb-distributions/pull/621
https://github.com/kiegroup/droolsjbpm-tools/pull/82
https://github.com/kiegroup/optaplanner-wb/pull/218
https://github.com/kiegroup/jbpm-wb/pull/864
https://github.com/kiegroup/jbpm-designer/pull/654
https://github.com/kiegroup/drools-wb/pull/596
https://github.com/kiegroup/kie-wb-common/pull/1133
https://github.com/kiegroup/droolsjbpm-integration/pull/1163
https://github.com/kiegroup/droolsjbpm-integration/pull/1163
https://github.com/kiegroup/jbpm/pull/973
https://github.com/kiegroup/drools/pull/1444
https://github.com/kiegroup/droolsjbpm-knowledge/pull/263
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/541
https://github.com/AppFormer/uberfire/pull/822