### PR TITLE
[AF-549-elastic]: Added new indexing backend to add elasticsearch support

### DIFF
--- a/jbpm-form-modeler-showcase/pom.xml
+++ b/jbpm-form-modeler-showcase/pom.xml
@@ -530,6 +530,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-commons-io</artifactId>
     </dependency>
 


### PR DESCRIPTION
A new Metadata index had been added. Its intention is to have an alternative to Lucene backend so you can use it, for instance in Openshift or on premise without zookeeper/helix to replicate those assets.

The idea is to maintain the same Lucene API but to transform it to Elasticsearch compatible messages. There is no need to change any Lucene Query to make it work. There is a class called **LuceneIndexEngine** that is not **public** anymore because it was very coupled to Lucene FS implementation so now it's behind a new Interface called **IndexProvider**. It tries to generate an abstraction for indexing a querying an index engine using domain objects and not lucene documents anymore.


The default indexing engine is Lucene but you can change it with a System Property:

- org.appformer.ext.metadata.index=elastic

There are some other properties to configure elasticsearch:

- org.appformer.ext.metadata.elastic.port
- org.appformer.ext.metadata.elastic.host
- org.appformer.ext.metadata.elastic.username
- org.appformer.ext.metadata.elastic.password
- org.appformer.ext.metadata.elastic.cluster

Related issues:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/581
https://github.com/AppFormer/uberfire/pull/882
https://github.com/kiegroup/kie-wb-common/pull/1254
https://github.com/kiegroup/jbpm-wb/pull/924
https://github.com/kiegroup/drools-wb/pull/666
https://github.com/kiegroup/optaplanner-wb/pull/228
https://github.com/kiegroup/jbpm-form-modeler/pull/150
https://github.com/kiegroup/kie-wb-distributions/pull/642